### PR TITLE
Add file permission fix

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -26,6 +26,7 @@
     <property name="message" value="Space needed around ':' character."/>
   </module>
 
+  <module name="SuppressWarningsFilter"/>
   <module name="TreeWalker">
     <property name="cacheFile" value="${checkstyle.cache.file}"/>
 
@@ -110,7 +111,6 @@
     <!--<module name="InnerAssignment"/>-->
     <!--module name="MagicNumber"/-->
     <module name="MissingSwitchDefault"/>
-    <module name="RedundantThrows"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
 
@@ -129,5 +129,7 @@
     <!--module name="FinalParameters"/-->
     <!--module name="TodoComment"/-->
     <module name="UpperEll"/>
+
+    <module name="SuppressWarningsHolder" />
   </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <module>spoon-client</module>
     <module>spoon-maven-plugin</module>
     <module>spoon-runner</module>
-    <!--<module>spoon-sample</module>-->
+    <module>spoon-sample</module>
   </modules>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <module>spoon-client</module>
     <module>spoon-maven-plugin</module>
     <module>spoon-runner</module>
-    <module>spoon-sample</module>
+    <!--<module>spoon-sample</module>-->
   </modules>
 
   <dependencyManagement>
@@ -207,7 +207,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.17</version>
         <configuration>
           <failsOnError>true</failsOnError>
           <configLocation>checkstyle.xml</configLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.squareup.spoon</groupId>
   <artifactId>parent</artifactId>
-  <version>1.1.3-EXP</version>
+  <version>1.1.3-EXP-SDK23</version>
   <packaging>pom</packaging>
 
   <name>Spoon (Parent)</name>

--- a/spoon-client/pom.xml
+++ b/spoon-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1.3-EXP</version>
+    <version>1.1.3-EXP-SDK23</version>
   </parent>
 
   <artifactId>spoon-client</artifactId>

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -50,11 +50,13 @@ public final class Spoon {
   }
 
   /** Overload method with extra testClass parameters to get screenshot on failure */
-  public static File screenshot(Activity activity, Instrumentation instrumentation, String tag, StackTraceElement testClass) {
+  public static File screenshot(Activity activity, Instrumentation instrumentation,
+      String tag, StackTraceElement testClass) {
     return getScreenshot(activity, instrumentation, tag, testClass);
   }
 
-  private static File getScreenshot(Activity activity, Instrumentation instrumentation, String tag, StackTraceElement testClass){
+  private static File getScreenshot(Activity activity, Instrumentation instrumentation,
+      String tag, StackTraceElement testClass) {
     if (!TAG_VALIDATION.matcher(tag).matches()) {
       throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
     }
@@ -64,8 +66,7 @@ public final class Spoon {
       File screenshotFile = new File(screenshotDirectory, screenshotName);
       if (Build.VERSION.SDK_INT < 18) {
         takeScreenshot(screenshotFile, activity);
-      }
-      else {
+      } else {
         SpoonCompatJellyBeanMR2.takeScreenshot(instrumentation, screenshotFile);
       }
       Log.d(TAG, "Captured screenshot '" + tag + "'.");
@@ -122,7 +123,8 @@ public final class Spoon {
     activity.getWindow().getDecorView().draw(canvas);
   }
 
-  private static File obtainScreenshotDirectory(Context context, StackTraceElement testClass) throws IllegalAccessException {
+  private static File obtainScreenshotDirectory(Context context,
+      StackTraceElement testClass) throws IllegalAccessException {
     File screenshotsDir = new File(Environment.getExternalStorageDirectory(),
         SPOON_SCREENSHOTS + "/" + context.getApplicationInfo().packageName);
 

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -147,7 +147,13 @@ public final class Spoon {
       StackTraceElement element = trace[i];
       if (TEST_CASE_CLASS.equals(element.getClassName()) //
           && TEST_CASE_METHOD.equals(element.getMethodName())) {
-        return trace[i - 3];
+            // the way we now call this method it ends up with #screenshot as the folder name
+            // when using [i-3]
+            if (trace[i - 3].getMethodName().equals("screenshot")) {
+              return trace[i - 2];
+            } else {
+              return trace[i - 3];
+            }
       }
     }
 

--- a/spoon-client/src/main/java/com/squareup/spoon/SpoonCompatJellyBeanMR2.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/SpoonCompatJellyBeanMR2.java
@@ -16,24 +16,24 @@ import static com.squareup.spoon.Chmod.chmodPlusR;
 
 public class SpoonCompatJellyBeanMR2 {
 
-	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-	protected static void takeScreenshot(Instrumentation instrumentation, File file) throws IOException {
-		final Bitmap bitmap = instrumentation.getUiAutomation().takeScreenshot();
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+    protected static void takeScreenshot(Instrumentation instrumentation,
+        File file) throws IOException {
+        final Bitmap bitmap = instrumentation.getUiAutomation().takeScreenshot();
 
-		OutputStream fos = null;
-		try {
-			fos = new BufferedOutputStream(new FileOutputStream(file));
-			bitmap.compress(PNG, 100 /* quality */, fos);
+        OutputStream fos = null;
+        try {
+            fos = new BufferedOutputStream(new FileOutputStream(file));
+            bitmap.compress(PNG, 100 /* quality */, fos);
 
-			chmodPlusR(file);
-		}
-		finally {
-			bitmap.recycle();
-			if (fos != null) {
-				fos.close();
-			}
-		}
+            chmodPlusR(file);
+        } finally {
+            bitmap.recycle();
+            if (fos != null) {
+                fos.close();
+            }
+        }
 
-	}
+    }
 
 }

--- a/spoon-maven-plugin/pom.xml
+++ b/spoon-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1.3-EXP</version>
+    <version>1.1.3-EXP-SDK23</version>
   </parent>
 
   <artifactId>spoon-maven-plugin</artifactId>

--- a/spoon-runner/pom.xml
+++ b/spoon-runner/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1.3-EXP</version>
+    <version>1.1.3-EXP-SDK23</version>
   </parent>
 
   <artifactId>spoon-runner</artifactId>

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceLogger.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceLogger.java
@@ -19,7 +19,7 @@ final class SpoonDeviceLogger implements LogCatListener {
   private final List<LogCatMessage> messages;
   private final LogCatReceiverTask logCatReceiverTask;
 
-  public SpoonDeviceLogger(IDevice device) {
+  SpoonDeviceLogger(IDevice device) {
     messages = new ArrayList<LogCatMessage>();
     logCatReceiverTask = new LogCatReceiverTask(device);
     logCatReceiverTask.addLogCatListener(this);

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -179,6 +179,24 @@ public final class SpoonDeviceRunner {
       return result.markInstallAsFailed(e.getMessage()).build();
     }
 
+    // If this is Android Marshmallow or above grant WRITE_EXTERNAL_STORAGE
+    if (Integer.parseInt(device.getProperty(IDevice.PROP_BUILD_API_LEVEL)) >= 23) {
+      String appPackage = instrumentationInfo.getApplicationPackage();
+      try {
+        CollectingOutputReceiver grantOutputReceiver = new CollectingOutputReceiver();
+        device.executeShellCommand("pm grant " + appPackage
+            + " android.permission.READ_EXTERNAL_STORAGE", grantOutputReceiver);
+        device.executeShellCommand("pm grant " + appPackage
+            + " android.permission.WRITE_EXTERNAL_STORAGE", grantOutputReceiver);
+      } catch (Exception e) {
+        logInfo("Exception while granting external storage access to application apk"
+            + "on device [%s]", serial);
+        e.printStackTrace(System.out);
+        return result.markInstallAsFailed("Unable to grant external storage access to"
+            + " application APK.").build();
+      }
+    }
+
     // Create the output directory, if it does not already exist.
     work.mkdirs();
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -1,6 +1,7 @@
 package com.squareup.spoon;
 
 import com.android.ddmlib.AndroidDebugBridge;
+import com.android.ddmlib.CollectingOutputReceiver;
 import com.android.ddmlib.IDevice;
 import com.android.ddmlib.InstallException;
 import com.android.ddmlib.SyncService;
@@ -139,6 +140,7 @@ public final class SpoonDeviceRunner {
   }
 
   /** Execute instrumentation on the target device and return a result summary. */
+  @SuppressWarnings("checkstyle:methodlength")
   public DeviceResult run(AndroidDebugBridge adb) {
     String appPackage = instrumentationInfo.getApplicationPackage();
     String testPackage = instrumentationInfo.getInstrumentationPackage();
@@ -181,7 +183,6 @@ public final class SpoonDeviceRunner {
 
     // If this is Android Marshmallow or above grant WRITE_EXTERNAL_STORAGE
     if (Integer.parseInt(device.getProperty(IDevice.PROP_BUILD_API_LEVEL)) >= 23) {
-      String appPackage = instrumentationInfo.getApplicationPackage();
       try {
         CollectingOutputReceiver grantOutputReceiver = new CollectingOutputReceiver();
         device.executeShellCommand("pm grant " + appPackage
@@ -210,8 +211,7 @@ public final class SpoonDeviceRunner {
       runner.setMaxtimeToOutputResponse(adbTimeout);
       if (!Strings.isNullOrEmpty(packageName)) {
         runner.setTestPackageName(packageName);
-      }
-      else if (!Strings.isNullOrEmpty(className)) {
+      } else if (!Strings.isNullOrEmpty(className)) {
         if (Strings.isNullOrEmpty(methodName)) {
           runner.setClassName(className);
         } else {

--- a/spoon-sample/app/pom.xml
+++ b/spoon-sample/app/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>spoon-sample</artifactId>
-    <version>1.1.3-EXP</version>
+    <version>1.1.3-EXP-SDK23</version>
   </parent>
 
   <artifactId>spoon-sample-app</artifactId>

--- a/spoon-sample/pom.xml
+++ b/spoon-sample/pom.xml
@@ -17,4 +17,8 @@
     <module>app</module>
     <module>tests</module>
   </modules>
+  <properties>
+    <checkstyle.skip>true</checkstyle.skip>
+  </properties>
+
 </project>

--- a/spoon-sample/pom.xml
+++ b/spoon-sample/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1.3-EXP</version>
+    <version>1.1.3-EXP-SDK23</version>
   </parent>
 
   <artifactId>spoon-sample</artifactId>

--- a/spoon-sample/tests/pom.xml
+++ b/spoon-sample/tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>spoon-sample</artifactId>
-    <version>1.1.3-EXP</version>
+    <version>1.1.3-EXP-SDK23</version>
   </parent>
 
   <artifactId>spoon-sample-tests</artifactId>


### PR DESCRIPTION
This pulls in a commit from square's repo to grant external storage access on SDK23+

Also the screenshot folder calculation seemed broken since it always used "screenshot" as the method/folder name. 

We should probably just rebase to the newest version but we're under a bit of a time constraint at the moment.
